### PR TITLE
Update setbits shifting field

### DIFF
--- a/chapter_2/exercise_2_06/setbits.c
+++ b/chapter_2/exercise_2_06/setbits.c
@@ -28,8 +28,8 @@ unsigned int setbits(int x, int p, int n, int y)
 {
   ++p; // First position is 0
 
-  unsigned int mask1 = (~(~(~0 << n) << p) & x);
-  unsigned int mask2 = (~(~0 << n) & y) << p;
+  unsigned int mask1 = (~(~(~0 << n) << (p-n)) & x);
+  unsigned int mask2 = (~(~0 << n) & y) << (p-n);
 
   return mask1 | mask2;
 }


### PR DESCRIPTION
follows the bit manipulation style (p as *MSB* of the field) demonstrated in K&R, particularly aligning with the `getbits` example (p+1-n). So bits to be set are the least after position p.